### PR TITLE
Bug 1245710 - move clientSuperShortname to shared.properties

### DIFF
--- a/l10n/af/shared.properties
+++ b/l10n/af/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ar/shared.properties
+++ b/l10n/ar/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/as/shared.properties
+++ b/l10n/as/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ast/shared.properties
+++ b/l10n/ast/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/az/add-on.properties
+++ b/l10n/az/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/az/shared.properties
+++ b/l10n/az/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Özünü göstərmə gizlədilib amma hələ də gönd�
 tos_failure_message={{clientShortname}} sizin ölkədə icazə verilmir.
 
 display_name_guest=Qonaq
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/be/shared.properties
+++ b/l10n/be/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/bg/add-on.properties
+++ b/l10n/bg/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/bg/shared.properties
+++ b/l10n/bg/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Какво виждат другите е скрито,
 tos_failure_message={{clientShortname}} е недостъпен във вашата държава.
 
 display_name_guest=Гост
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/bn_BD/add-on.properties
+++ b/l10n/bn_BD/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/bn_BD/shared.properties
+++ b/l10n/bn_BD/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=সেলফ-ভিউ লুকানো কিন্�
 tos_failure_message={{clientShortname}} আপনার দেশের বিদ্যমান নয়।
 
 display_name_guest=অতিথি
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/bn_IN/shared.properties
+++ b/l10n/bn_IN/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=স্বয়ং-ভিউ লোকানো কিন�
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/bs/shared.properties
+++ b/l10n/bs/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ca/shared.properties
+++ b/l10n/ca/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=La vista pròpia està amagada, però encara s'està en
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message=El {{clientShortname}} no està disponible al vostre país.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/cs/add-on.properties
+++ b/l10n/cs/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/cs/shared.properties
+++ b/l10n/cs/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Váš obraz byl skryt, ale je nadále odesílán; pro j
 tos_failure_message={{clientShortname}} není ve vaší zemi dostupný.
 
 display_name_guest=Host
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/cy/add-on.properties
+++ b/l10n/cy/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/cy/shared.properties
+++ b/l10n/cy/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=Golwg o'ch hun yn cael ei guddio ond yn dal i gael ei a
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message=Nid yw {{clientShortname}} ar gael yn eich gwlad.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/da/add-on.properties
+++ b/l10n/da/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/da/shared.properties
+++ b/l10n/da/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Billedet fra eget kamera er skjult, men sendes stadig t
 tos_failure_message={{clientShortname}} er ikke tilgængelig i dit land.
 
 display_name_guest=Gæst
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/de/add-on.properties
+++ b/l10n/de/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/de/shared.properties
+++ b/l10n/de/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=Die Verbindung zu Ihrem Freund wurde unerwartet getrennt.
 tos_failure_message={{clientShortname}} ist in Ihrem Land nicht verfügbar.
 
 display_name_guest=Gast
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/dsb/add-on.properties
+++ b/l10n/dsb/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/dsb/shared.properties
+++ b/l10n/dsb/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=Zwisk z wašym pśijaśelom jo se źělił.
 tos_failure_message={{clientShortname}} njestoj we wašom kraju k dispoziciji.
 
 display_name_guest=Gósć
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/el/shared.properties
+++ b/l10n/el/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Το βίντεο σας εμφανίζεται μόν�
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/en_GB/add-on.properties
+++ b/l10n/en_GB/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/en_GB/shared.properties
+++ b/l10n/en_GB/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window \\
 tos_failure_message={{clientShortname}} is not available in your country.
 
 display_name_guest=Guest
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/eo/shared.properties
+++ b/l10n/eo/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=Propra vido kaŝita, sed tamen sendata. Ŝanĝu la gran
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}} ne disponeblas en via lando.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/es-CL/add-on.properties
+++ b/l10n/es-CL/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/es-CL/shared.properties
+++ b/l10n/es-CL/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=La vista local está oculta pero continúa siendo envia
 tos_failure_message={{clientShortname}} no está disponible en tu país.
 
 display_name_guest=Invitado
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/es-ES/add-on.properties
+++ b/l10n/es-ES/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/es-ES/shared.properties
+++ b/l10n/es-ES/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Se está enviando la vista propia aunque esté oculta; 
 tos_failure_message={{clientShortname}} no está disponible en tu país.
 
 display_name_guest=Invitado
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/es-MX/add-on.properties
+++ b/l10n/es-MX/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/es-MX/shared.properties
+++ b/l10n/es-MX/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Auto-vista oculta pero enviándose; redimensiona ventan
 tos_failure_message={{clientShortname}} no está disponible en tu país.
 
 display_name_guest=Invitado
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/et/shared.properties
+++ b/l10n/et/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Sinu pilti edastatakse, kuid see on praegu peidetud. Pi
 tos_failure_message={{clientShortname}} pole sinu riigis saadaval.
 
 display_name_guest=Külaline
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/eu/shared.properties
+++ b/l10n/eu/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Norbere ikuspegia ezkutatuta baina oraindik bidaltzen; 
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/fa/add-on.properties
+++ b/l10n/fa/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/fa/shared.properties
+++ b/l10n/fa/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=نمای فردی پنهان شده است ولی ار�
 tos_failure_message={{clientShortname}} در کشور شما در دسترس نیست.
 
 display_name_guest=مهمان
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ff/shared.properties
+++ b/l10n/ff/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Jiytol maa koko suuɗii kono ena yaha haa jooni; ɓeydu
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/fi/shared.properties
+++ b/l10n/fi/shared.properties
@@ -37,3 +37,7 @@ self_view_hidden_message=Omanäkymä piilotettu, mutta lähetetään edelleen. M
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/fr/add-on.properties
+++ b/l10n/fr/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/fr/shared.properties
+++ b/l10n/fr/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=L’autre personne a été brusquement déconnectée.
 tos_failure_message={{clientShortname}} n'est pas disponible dans votre pays.
 
 display_name_guest=Invité
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/fy_NL/add-on.properties
+++ b/l10n/fy_NL/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/fy_NL/shared.properties
+++ b/l10n/fy_NL/shared.properties
@@ -45,3 +45,11 @@ self_view_hidden_message=Eigen werjefte ferburgen, mar wurdt noch hieltyd ferstj
 tos_failure_message={{clientShortname}} is net beskikber yn jo lân.
 
 display_name_guest=Gast
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ga/shared.properties
+++ b/l10n/ga/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/gd/add-on.properties
+++ b/l10n/gd/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/gd/shared.properties
+++ b/l10n/gd/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Tha do dhealbh fhèin am falach ach 'ga chur fhathast; 
 tos_failure_message=Chan eil {{clientShortname}} ri fhaighinn ’nad dhùthaich.
 
 display_name_guest=Aoigh
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/gl/shared.properties
+++ b/l10n/gl/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/gu_IN/shared.properties
+++ b/l10n/gu_IN/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/he/shared.properties
+++ b/l10n/he/shared.properties
@@ -30,3 +30,7 @@ rooms_room_join_label=הצטרפות לדיון
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/hi_IN/shared.properties
+++ b/l10n/hi_IN/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=निजी-दृश्य छुपा हुआ ह
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/hr/shared.properties
+++ b/l10n/hr/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/hsb/shared.properties
+++ b/l10n/hsb/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=Zwisk z wašim přećelo je so njenadźicy dzělił.
 tos_failure_message={{clientShortname}} we wašim kraju k dispoziciji njesteji.
 
 display_name_guest=Hósć
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ht/shared.properties
+++ b/l10n/ht/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/hu/add-on.properties
+++ b/l10n/hu/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/hu/shared.properties
+++ b/l10n/hu/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=A saját kamera képe elrejtve, de elküldésre kerül.
 tos_failure_message=A {{clientShortname}} nem érhető el ebben az országban.
 
 display_name_guest=Vendég
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/hy_AM/add-on.properties
+++ b/l10n/hy_AM/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/hy_AM/shared.properties
+++ b/l10n/hy_AM/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Ինքնադիտումը թաքցված է, բայց դ
 tos_failure_message={{clientShortname}}-ը հասանելի չէ ձեր երկրում:
 
 display_name_guest=Հյուր
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/id/add-on.properties
+++ b/l10n/id/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/id/shared.properties
+++ b/l10n/id/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Tampilan diri sedang tersembunyi tetapi tetap dikirim, 
 tos_failure_message={{clientShortname}} tidak tersedia di negara Anda.
 
 display_name_guest=Tamu
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/it/add-on.properties
+++ b/l10n/it/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/it/shared.properties
+++ b/l10n/it/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=L’anteprima della fotocamera è nascosta, ma l’inte
 tos_failure_message={{clientShortname}} non è disponibile per questa nazione.
 
 display_name_guest=Ospite
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ja/add-on.properties
+++ b/l10n/ja/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/ja/shared.properties
+++ b/l10n/ja/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=セルフビューは隠れていますが送信され�
 tos_failure_message={{clientShortname}} はあなたがお住まいの国では利用できません。
 
 display_name_guest=ゲスト
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/kk/add-on.properties
+++ b/l10n/kk/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/kk/shared.properties
+++ b/l10n/kk/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Өздік көрініс жасырылған, бір�
 tos_failure_message={{clientShortname}} сіздің еліңізде қолжетерсіз.
 
 display_name_guest=Қонақ
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/km/shared.properties
+++ b/l10n/km/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/kn/shared.properties
+++ b/l10n/kn/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=ಸ್ವ-ನೋಟ ಮರೆಯಾಗಿಸಲಾಗ�
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ko/add-on.properties
+++ b/l10n/ko/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/ko/shared.properties
+++ b/l10n/ko/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=자기 보기 모드는 숨겨졌으나 전달됩니다
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}}는 현재 지역에서 사용할 수 없습니다.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ku/shared.properties
+++ b/l10n/ku/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/lij/add-on.properties
+++ b/l10n/lij/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/lij/shared.properties
+++ b/l10n/lij/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=A vista de ti a l'é ascoza ma a l'é ancon trasmissa; 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}} o no gh'é into teu paize.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/lt/shared.properties
+++ b/l10n/lt/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=Jūs savo atvaizdo nematote, bet jis yra siunčiamas pa
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message=„{{clientShortname}}“ paslauga jūsų šalyje neteikiama.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/lv/shared.properties
+++ b/l10n/lv/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Jūsu paša skats ir paslēpts, bet joprojām tiek sūt
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/mk/shared.properties
+++ b/l10n/mk/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ml/shared.properties
+++ b/l10n/ml/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=സ്വയം-കാഴ്ച അദൃശ്യമ�
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}} താങ്കളുടെ രാജ്യത്തു് ലഭ്യമല്ല.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/mn/shared.properties
+++ b/l10n/mn/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ms/shared.properties
+++ b/l10n/ms/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/my/shared.properties
+++ b/l10n/my/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/nb_NO/shared.properties
+++ b/l10n/nb_NO/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Bildet fra eget kamera er skjult, men blir fortsatt sen
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ne_NP/shared.properties
+++ b/l10n/ne_NP/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/nl/add-on.properties
+++ b/l10n/nl/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/nl/shared.properties
+++ b/l10n/nl/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=Uw vriend heeft onverwacht de verbinding verbroken.
 tos_failure_message={{clientShortname}} is niet in uw land beschikbaar.
 
 display_name_guest=Gast
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/or/shared.properties
+++ b/l10n/or/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/pa_IN/shared.properties
+++ b/l10n/pa_IN/shared.properties
@@ -42,3 +42,11 @@ self_view_hidden_message=ਸਵੈ-ਦ੍ਰਿਸ਼ ਓਹਲੇ ਹੈ, ਪਰ �
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}} ਤੁਹਾਡੇ ਦੇ ਵਿੱਚ ਉਪਲੱਬਧ ਨਹੀਂ ਹੈ।
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/pl/shared.properties
+++ b/l10n/pl/shared.properties
@@ -34,3 +34,7 @@ self_view_hidden_message=Obraz z kamery jest ukryty ale nadal wysyłany (powię
 tos_failure_message=Usługa {{clientShortname}} nie jest dostępna w tym kraju.
 
 display_name_guest=Gość
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/pt/shared.properties
+++ b/l10n/pt/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Vista própria oculta mas ainda a ser enviada; redimens
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/pt_BR/add-on.properties
+++ b/l10n/pt_BR/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/pt_BR/shared.properties
+++ b/l10n/pt_BR/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=A visualização da sua câmera está oculta, mas ainda
 tos_failure_message={{clientShortname}} não está disponível no seu país.
 
 display_name_guest=Convidado
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/pt_PT/add-on.properties
+++ b/l10n/pt_PT/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/pt_PT/shared.properties
+++ b/l10n/pt_PT/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=O seu amigo foi desligado de forma inesperada.
 tos_failure_message={{clientShortname}} não está disponível no seu país.
 
 display_name_guest=Visitante
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/rm/add-on.properties
+++ b/l10n/rm/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/rm/shared.properties
+++ b/l10n/rm/shared.properties
@@ -43,3 +43,7 @@ self_view_hidden_message=Tes video è zuppentà, ma vegn anc adina transmess; en
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}} n'è betg disponibel en tes pajais.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ro/shared.properties
+++ b/l10n/ro/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=Auto-vedere ascunsă dar e transmisă în continuare; r
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}} nu este disponibil în țara ta.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ru/add-on.properties
+++ b/l10n/ru/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/ru/shared.properties
+++ b/l10n/ru/shared.properties
@@ -46,3 +46,7 @@ self_view_hidden_message=Вид самого себя скрыт, но всё ж
 tos_failure_message={{clientShortname}} не доступен в вашей стране.
 
 display_name_guest=Гость
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/si/shared.properties
+++ b/l10n/si/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/sk/add-on.properties
+++ b/l10n/sk/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/sk/shared.properties
+++ b/l10n/sk/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=Váš priateľ neočakávane ukončil spojenie.
 tos_failure_message={{clientShortname}} nie je vo vašej krajine dostupný.
 
 display_name_guest=Hosť
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/sl/add-on.properties
+++ b/l10n/sl/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/sl/shared.properties
+++ b/l10n/sl/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=Lasten pogled skrit, vendar se še vedno pošilja. Raz�
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}} v vaši državi ni na voljo.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/son/shared.properties
+++ b/l10n/son/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}} is not available in your country.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/sq/add-on.properties
+++ b/l10n/sq/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/sq/shared.properties
+++ b/l10n/sq/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=I vetëfshehur, por prapë i dukshëm; ripërmasoni dri
 tos_failure_message={{clientShortname}} s’është i passhëm në vendin tuaj.
 
 display_name_guest=Mysafir
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/sr/add-on.properties
+++ b/l10n/sr/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/sr/shared.properties
+++ b/l10n/sr/shared.properties
@@ -42,3 +42,7 @@ self_view_hidden_message=Приказ вашег екрана је сакрив�
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
 tos_failure_message={{clientShortname}} није доступан у вашој држави.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/sv_SE/shared.properties
+++ b/l10n/sv_SE/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=Din vän har oväntat kopplats bort.
 tos_failure_message={{clientShortname}} är inte tillgänglig i ditt land.
 
 display_name_guest=Gäst
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ta/shared.properties
+++ b/l10n/ta/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=நீங்கள் மறைக்கப்பட்
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/te/shared.properties
+++ b/l10n/te/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/templates/add-on.properties
+++ b/l10n/templates/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/templates/shared.properties
+++ b/l10n/templates/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=Your friend has unexpectedly disconnected.
 tos_failure_message={{clientShortname}} is not available in your country.
 
 display_name_guest=Guest
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/th/shared.properties
+++ b/l10n/th/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/tr/add-on.properties
+++ b/l10n/tr/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/tr/shared.properties
+++ b/l10n/tr/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Kendi görünümünüz gizlendi ama hâlâ gönderiliyo
 tos_failure_message={{clientShortname}} ülkenizde kullanılamıyor.
 
 display_name_guest=Misafir
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/uk/add-on.properties
+++ b/l10n/uk/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/uk/shared.properties
+++ b/l10n/uk/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=Вигляд самого себе прихований
 tos_failure_message={{clientShortname}} недоступний у вашій країні.
 
 display_name_guest=Гість
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/ur/shared.properties
+++ b/l10n/ur/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/vi/shared.properties
+++ b/l10n/vi/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/xh/shared.properties
+++ b/l10n/xh/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/zh_CN/add-on.properties
+++ b/l10n/zh_CN/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/zh_CN/shared.properties
+++ b/l10n/zh_CN/shared.properties
@@ -48,3 +48,7 @@ peer_unexpected_quit=您的朋友已意外断开。
 tos_failure_message={{clientShortname}} 在您的国家不可用。
 
 display_name_guest=访客
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/zh_TW/add-on.properties
+++ b/l10n/zh_TW/add-on.properties
@@ -4,7 +4,7 @@
 
 # Panel Strings
 
-clientSuperShortname=Hello
+
 
 ## LOCALIZATION_NOTE(loopMenuItem_label): Label of the menu item that is placed
 ## inside the browser 'Tools' menu. Use the unicode ellipsis char, \u2026, or

--- a/l10n/zh_TW/shared.properties
+++ b/l10n/zh_TW/shared.properties
@@ -45,3 +45,7 @@ self_view_hidden_message=已隱藏您自己的畫面，但還是會送出。請�
 tos_failure_message=無法在您所在的國家使用 {{clientShortname}}。
 
 display_name_guest=訪客
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello

--- a/l10n/zu/shared.properties
+++ b/l10n/zu/shared.properties
@@ -38,3 +38,7 @@ self_view_hidden_message=Self-view hidden but still being sent; resize window to
 
 ## LOCALIZATION NOTE (tos_failure_message): Don't translate {{clientShortname}}
 ## as this will be replaced by clientShortname2.
+
+## LOCALIZATION NOTE(clientSuperShortname): This should not be localized and
+## should remain "Hello" for all locales.
+clientSuperShortname=Hello


### PR DESCRIPTION
This deletes clientSuperShortname from add-on.properties in the template as well as all locales that have it present.  It replaces it with a blank line, which I'd ideally remove, but doesn't seem worth the time given the other things in the air right now.

It adds clientSuperShortname with a "don't translate me" note into shared.properties in the template and all locales.

I haven't really tested it, because it's not obvious to me an easy way to do that.  Suggestions welcomed.
